### PR TITLE
[ player ] adicionado botão de play quando for mobile

### DIFF
--- a/views/watch.html
+++ b/views/watch.html
@@ -14,6 +14,11 @@
     thumb130: '{{ thumb130 }}',
     runtime: '{{ runtime }}'
   }];
+  $(document).ready(function(){
+    if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+        document.getElementsByClassName('pl-mobile-play')[0].style.display = "block";
+    }
+  })
 </script>
 
 <style media="screen" type="text/css">
@@ -29,6 +34,7 @@
 <libreplayer>
 
   <body onload="Q()" id="go" class="libreplayer">
+    <button type="button" id="pl-playback-play" class="pl-button pl-mobile-play" onclick="this.style.cssText='display:none'" style="z-index: 99; display:none"><img src="https://libreflix.org/img/ico-play.png"></button>
 
     <div id="pl-player" class="stretch loading">
       <div id="pl-video-wrap" class="stretch">


### PR DESCRIPTION
Para navegadores mobile, como por exemplo o Safari mobile é necessário o usuário dar o play nos vídeos. O autoplay está indisponível em alguns navegadores mobiles. Adicionando esse botão no topo, ao clicar nele, ele é automaticamente escondido e só exibido em navegadores mobile.

Referência:
https://developers.google.com/youtube/iframe_api_reference#Mobile_considerations